### PR TITLE
reduce allocations

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-    <packageSources>
-        <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
-    </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="dotnet-core" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+    </packageSources>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A set of Tag Helpers that can capture a script block and render it later in anot
     ```
 1. Register the Tag Helpers in your application's `_ViewImports.cshtml` file:
     ```
-    @addTagHelper *, TagHelperPack
+    @addTagHelper *, ScriptCaptureTagHelper
     ```
     
 ## Usage:
@@ -50,7 +50,7 @@ later it can be rendered via single `script` tag:
 ```html
 <script render='Foo'></script>
 ```
-which will expand into two captured tags.
+which will expand into a script tag that contains content from two captured tags.
 2. Control the order in which captured scripts will be rendered by specifying `priority` attribute.
     This attribute is optional, if not specified block will be rendered as the last one.
 3. `script` tag attributes are now preserved, which enables the scenario for capturing script reference:

--- a/ScriptCaptureTagHelper.Benchmarks/Benchmarks/ScriptTagBenchmark.cs
+++ b/ScriptCaptureTagHelper.Benchmarks/Benchmarks/ScriptTagBenchmark.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace ScriptCaptureTagHelper.Benchmarks.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class ScriptTagBenchmark
+    {
+        private ViewContext _viewContext;
+        private ScriptRenderTagHelper renderTag;
+        private TagHelperOutput renderOutput;
+        private TagHelperContext renderContext;
+
+        [Params(1_000, 10_000, 100_000)]
+        public int StringLength { get; set; }
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            _viewContext = new ViewContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+            
+            var random = new Random();
+            var randomString = new string(Enumerable.Range(0, StringLength).Select(n => (char) random.Next()).ToArray());
+            var captureOutput = CreateCaptureTagWith(randomString);
+            this.renderOutput = CreateRenderTag();
+            this.renderContext = CreateHelperContext();
+            
+            ProcessCaptureHelper(captureOutput, "current").GetAwaiter().GetResult();
+            this.renderTag = new ScriptRenderTagHelper
+            {
+                Render = "current",
+                ViewContext = _viewContext
+            };
+        }
+
+        [Benchmark]
+        public string Process()
+        {
+            renderTag.ProcessAsync(renderContext, renderOutput);
+            return renderOutput.Content.GetContent();
+        }
+        
+        private async Task ProcessCaptureHelper(TagHelperOutput output, string name = "UniqueValue", int? priority = null)
+        {
+            var captureTag = new ScriptCaptureTagHelper
+            {
+                Capture = name,
+                Priority = priority,
+                ViewContext = _viewContext
+            };
+            
+            await captureTag.ProcessAsync(CreateHelperContext(), output);                   
+        }
+        
+        private static TagHelperOutput CreateCaptureTagWith(string content)
+            => new TagHelperOutput("capture",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(content);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+        
+        private static TagHelperOutput CreateRenderTag()
+            => new TagHelperOutput("render",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(string.Empty);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+        private static TagHelperContext CreateHelperContext()
+            => new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+    }
+}

--- a/ScriptCaptureTagHelper.Benchmarks/Program.cs
+++ b/ScriptCaptureTagHelper.Benchmarks/Program.cs
@@ -1,0 +1,13 @@
+﻿using BenchmarkDotNet.Running;
+using ScriptCaptureTagHelper.Benchmarks.Benchmarks;
+
+namespace ScriptCaptureTagHelper.Benchmarks
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            BenchmarkRunner.Run<ScriptTagBenchmark>();
+        }
+    }
+}

--- a/ScriptCaptureTagHelper.Benchmarks/ScriptCaptureTagHelper.Benchmarks.csproj
+++ b/ScriptCaptureTagHelper.Benchmarks/ScriptCaptureTagHelper.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />

--- a/ScriptCaptureTagHelper.Benchmarks/ScriptCaptureTagHelper.Benchmarks.csproj
+++ b/ScriptCaptureTagHelper.Benchmarks/ScriptCaptureTagHelper.Benchmarks.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.13" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ScriptCaptureTagHelper\ScriptCaptureTagHelper.csproj" />
+  </ItemGroup>
+</Project>

--- a/ScriptCaptureTagHelper.Sample/Controllers/HomeController.cs
+++ b/ScriptCaptureTagHelper.Sample/Controllers/HomeController.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using ScriptCaptureTagHelper.Sample.Models;
+
+namespace ScriptCaptureTagHelper.Sample.Controllers
+{
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {    
+            return View(new DisplayModel());
+        }
+    }
+}

--- a/ScriptCaptureTagHelper.Sample/Models/DisplayModel.cs
+++ b/ScriptCaptureTagHelper.Sample/Models/DisplayModel.cs
@@ -1,0 +1,6 @@
+﻿namespace ScriptCaptureTagHelper.Sample.Models
+{
+    public class DisplayModel : ViewModel
+    {
+    }
+}

--- a/ScriptCaptureTagHelper.Sample/Models/ViewModel.cs
+++ b/ScriptCaptureTagHelper.Sample/Models/ViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace ScriptCaptureTagHelper.Sample.Models
+{
+    public class ViewModel
+    {
+    }
+}

--- a/ScriptCaptureTagHelper.Sample/Program.cs
+++ b/ScriptCaptureTagHelper.Sample/Program.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Hosting;
+
+namespace ScriptCaptureTagHelper.Sample
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateWebHostBuilder(args).Build().Run();
+        }
+
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
+            WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>();
+    }
+}

--- a/ScriptCaptureTagHelper.Sample/ScriptCaptureTagHelper.Sample.csproj
+++ b/ScriptCaptureTagHelper.Sample/ScriptCaptureTagHelper.Sample.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview1-final" />
-  </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.6" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ScriptCaptureTagHelper\ScriptCaptureTagHelper.csproj" />

--- a/ScriptCaptureTagHelper.Sample/ScriptCaptureTagHelper.Sample.csproj
+++ b/ScriptCaptureTagHelper.Sample/ScriptCaptureTagHelper.Sample.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-preview1-final" />
+  </ItemGroup>
+  <ItemGroup>
+    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.1.0-preview1-final" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ScriptCaptureTagHelper\ScriptCaptureTagHelper.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Views\Shared" />
+  </ItemGroup>
+</Project>

--- a/ScriptCaptureTagHelper.Sample/Startup.cs
+++ b/ScriptCaptureTagHelper.Sample/Startup.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ScriptCaptureTagHelper.Sample
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
+        }
+        
+        public void Configure(IApplicationBuilder app)
+        {
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                    name: "default",
+                    template: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/ScriptCaptureTagHelper.Sample/Views/Home/Index.cshtml
+++ b/ScriptCaptureTagHelper.Sample/Views/Home/Index.cshtml
@@ -1,0 +1,6 @@
+﻿@model ScriptCaptureTagHelper.Sample.Models.ViewModel
+<div>Main View</div>
+@Html.DisplayForModel()
+
+<script render="Foo">
+</script>

--- a/ScriptCaptureTagHelper.Sample/Views/Shared/DisplayTemplates/DisplayModel.cshtml
+++ b/ScriptCaptureTagHelper.Sample/Views/Shared/DisplayTemplates/DisplayModel.cshtml
@@ -1,0 +1,9 @@
+﻿@model ScriptCaptureTagHelper.Sample.Models.DisplayModel
+
+<div>Display Template</div>
+<script capture="Foo">
+    console.log('Foo 1');
+</script>
+<script capture="Foo">
+    console.log('Foo 2');
+</script>

--- a/ScriptCaptureTagHelper.Sample/Views/_ViewImports.cshtml
+++ b/ScriptCaptureTagHelper.Sample/Views/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+﻿@using ScriptCaptureTagHelper.Sample
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, ScriptCaptureTagHelper

--- a/ScriptCaptureTagHelper.Sample/appsettings.json
+++ b/ScriptCaptureTagHelper.Sample/appsettings.json
@@ -1,0 +1,7 @@
+﻿{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning"
+    }
+  }
+}

--- a/ScriptCaptureTagHelper.UnitTests/RenderShould.cs
+++ b/ScriptCaptureTagHelper.UnitTests/RenderShould.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace ScriptCaptureTagHelper.UnitTests
+{
+    public class RenderShould
+    {
+        private readonly ViewContext _viewContext;
+
+        public RenderShould()
+        {
+            _viewContext = new ViewContext
+            {
+                HttpContext = new DefaultHttpContext()
+            };
+        }
+        
+        [Fact]
+        public async Task HaveEmptyCaptureOutput()
+        {
+            var captureOutput = CreateCaptureTagWith("console.log('Foo');");
+            
+            await ProcessCaptureHelper(captureOutput);
+
+            var content = captureOutput.Content.GetContent();
+            content.Should().Be("");
+        }
+
+        [Theory]
+        [InlineData("console.log('Foo');")]
+        [InlineData("console.log('Bar');")]
+        public async Task RenderCaptureOutput(string captureContent)
+        {
+            var captureOutput = CreateCaptureTagWith(captureContent);
+            var renderOutput = CreateRenderTag();
+            await ProcessCaptureHelper(captureOutput);
+            
+            await ProcessRenderHelper(renderOutput);
+            
+            var content = renderOutput.Content.GetContent();
+            content.Should().Be($"{captureContent}{Environment.NewLine}");
+        }
+
+        [Theory]
+        [InlineData("1", "2")]
+        [InlineData("2", "1")]
+        public async Task RespectPriority(string script1, string script2)
+        {
+            var captureOutput1 = CreateCaptureTagWith(script1);
+            var captureOutput2 = CreateCaptureTagWith(script2);
+            var renderOutput = CreateRenderTag();
+            await ProcessCaptureHelper(captureOutput1);
+            await ProcessCaptureHelper(captureOutput2);
+            
+            await ProcessRenderHelper(renderOutput);
+            
+            var content = renderOutput.Content.GetContent();
+            content.Should().Be($"{script1}{Environment.NewLine}{script2}{Environment.NewLine}");
+        }
+
+        private async Task ProcessRenderHelper(TagHelperOutput tagHelperOutput, string name = "UniqueValue")
+        {
+            var renderTag = new ScriptRenderTagHelper
+            {
+                Render = name,
+                ViewContext = _viewContext
+            };
+            
+            await renderTag.ProcessAsync(CreateHelperContext(), tagHelperOutput);
+        }
+        
+        private async Task ProcessCaptureHelper(TagHelperOutput output, string name = "UniqueValue", int? priority = null)
+        {
+            var captureTag = new ScriptCaptureTagHelper
+            {
+                Capture = name,
+                Priority = priority,
+                ViewContext = _viewContext
+            };
+            
+            await captureTag.ProcessAsync(CreateHelperContext(), output);                   
+        }
+
+        private static TagHelperOutput CreateCaptureTagWith(string content)
+            => new TagHelperOutput("capture",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(content);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+        
+        private static TagHelperOutput CreateRenderTag()
+            => new TagHelperOutput("render",
+                new TagHelperAttributeList(),
+                (result, encoder) =>
+                {
+                    var tagHelperContent = new DefaultTagHelperContent();
+                    tagHelperContent.SetHtmlContent(string.Empty);
+                    return Task.FromResult<TagHelperContent>(tagHelperContent);
+                });
+
+        private static TagHelperContext CreateHelperContext()
+            => new TagHelperContext(
+                new TagHelperAttributeList(),
+                new Dictionary<object, object>(),
+                Guid.NewGuid().ToString("N"));
+    }
+}

--- a/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
+++ b/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
@@ -6,9 +6,8 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ScriptCaptureTagHelper\ScriptCaptureTagHelper.csproj" />

--- a/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
+++ b/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0-preview-20180109-01" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ScriptCaptureTagHelper\ScriptCaptureTagHelper.csproj" />
+  </ItemGroup>
+</Project>

--- a/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
+++ b/ScriptCaptureTagHelper.UnitTests/ScriptCaptureTagHelper.UnitTests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0-preview-20180109-01" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/ScriptCaptureTagHelper.sln
+++ b/ScriptCaptureTagHelper.sln
@@ -8,6 +8,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{53D5411B-E1D2-4AE0-BC1E-3BB00042E657}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
+		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCaptureTagHelper.Sample", "ScriptCaptureTagHelper.Sample\ScriptCaptureTagHelper.Sample.csproj", "{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}"

--- a/ScriptCaptureTagHelper.sln
+++ b/ScriptCaptureTagHelper.sln
@@ -8,7 +8,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{53D5411B-E1D2-4AE0-BC1E-3BB00042E657}"
 	ProjectSection(SolutionItems) = preProject
 		README.md = README.md
-		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCaptureTagHelper.Sample", "ScriptCaptureTagHelper.Sample\ScriptCaptureTagHelper.Sample.csproj", "{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}"

--- a/ScriptCaptureTagHelper.sln
+++ b/ScriptCaptureTagHelper.sln
@@ -10,6 +10,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCaptureTagHelper.Sample", "ScriptCaptureTagHelper.Sample\ScriptCaptureTagHelper.Sample.csproj", "{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCaptureTagHelper.UnitTests", "ScriptCaptureTagHelper.UnitTests\ScriptCaptureTagHelper.UnitTests.csproj", "{B25A8143-90B1-4354-B61F-DF5CFE17A218}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ScriptCaptureTagHelper.Benchmarks", "ScriptCaptureTagHelper.Benchmarks\ScriptCaptureTagHelper.Benchmarks.csproj", "{095C309B-28E3-4445-B31F-393730FFB93C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +26,18 @@ Global
 		{C4498188-CB12-436B-B16F-4FEEE77440D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C4498188-CB12-436B-B16F-4FEEE77440D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C4498188-CB12-436B-B16F-4FEEE77440D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0A699A0-1BBF-4A63-8DEE-3959D1145B5A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B25A8143-90B1-4354-B61F-DF5CFE17A218}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B25A8143-90B1-4354-B61F-DF5CFE17A218}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B25A8143-90B1-4354-B61F-DF5CFE17A218}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B25A8143-90B1-4354-B61F-DF5CFE17A218}.Release|Any CPU.Build.0 = Release|Any CPU
+		{095C309B-28E3-4445-B31F-393730FFB93C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{095C309B-28E3-4445-B31F-393730FFB93C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{095C309B-28E3-4445-B31F-393730FFB93C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{095C309B-28E3-4445-B31F-393730FFB93C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ScriptCaptureTagHelper/ScriptCaptureTagHelper.cs
+++ b/ScriptCaptureTagHelper/ScriptCaptureTagHelper.cs
@@ -33,25 +33,27 @@ namespace ScriptCaptureTagHelper
         {
             if (string.IsNullOrEmpty(Capture))
                 return;
-
+            
             var attributes = context.AllAttributes
                 .Where(a => !string.Equals(a.Name, "capture", System.StringComparison.OrdinalIgnoreCase) && 
                             !string.Equals(a.Name, "priority", System.StringComparison.OrdinalIgnoreCase))
                 .ToDictionary(k => k.Name, v => v.Value);
             var content = await output.GetChildContentAsync();
             var key = $"Script_{Capture}";
-            ScriptCapture capture;
+            ScriptCapture capture = null;
             if (ViewContext.HttpContext.Items.ContainsKey(key))
             {
                 capture = ViewContext.HttpContext.Items[key] as ScriptCapture;
             }
-            else
+            
+            if (capture == null)
             {
                 capture = new ScriptCapture();
                 ViewContext.HttpContext.Items.Add(key, capture);
             }
+            
             var order = Priority ?? int.MaxValue;
-            capture.Add(content.GetContent(), attributes, order);
+            capture.Add(content, attributes, order);
             output.SuppressOutput();
         }
     }

--- a/ScriptCaptureTagHelper/ScriptRenderTagHelper.cs
+++ b/ScriptCaptureTagHelper/ScriptRenderTagHelper.cs
@@ -1,16 +1,16 @@
-﻿using Microsoft.AspNetCore.Mvc.Rendering;
+﻿using Microsoft.AspNetCore.Mvc.Razor;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using ScriptCaptureTagHelper.Types;
 using System.Linq;
-using Microsoft.AspNetCore.Mvc.Razor;
 
 namespace ScriptCaptureTagHelper
 {
     /// <summary>
     /// Renders a script block that was stored by <see cref="ScriptCaptureTagHelper"/>
     /// </summary>
-    [HtmlTargetElement(ScriptTag, Attributes = "render")]
+    [HtmlTargetElement("script", Attributes = "render")]
     public class ScriptRenderTagHelper : TagHelper
     {
         private const string ScriptTag = "script";
@@ -39,7 +39,14 @@ namespace ScriptCaptureTagHelper
             {
                 foreach (var block in capture.Blocks.OrderBy(b => b.Order))
                 {
-                    block.Content.WriteTo(tw, NullHtmlEncoder.Default);
+                    var tagBuilder = new TagBuilder(ScriptTag)
+                    {
+                        TagRenderMode = TagRenderMode.Normal
+                    };
+                    tagBuilder.InnerHtml.AppendHtml(block.Content);
+                    tagBuilder.MergeAttributes(block.Attributes, replaceExisting: true);
+                    tagBuilder.WriteTo(tw, NullHtmlEncoder.Default);
+                    
                     await tw.WriteLineAsync();
                 }
             }));

--- a/ScriptCaptureTagHelper/Types/ScriptBlock.cs
+++ b/ScriptCaptureTagHelper/Types/ScriptBlock.cs
@@ -1,17 +1,18 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace ScriptCaptureTagHelper.Types
 {
-    public class ScriptBlock
+    public struct ScriptBlock
     {
-        public ScriptBlock(string content, Dictionary<string, object> attributes, int order)
+        public ScriptBlock(TagHelperContent content, Dictionary<string, object> attributes, int order)
         {
             Content = content;
             Attributes = attributes;
             Order = order;
         }
 
-        public string Content { get; }
+        public TagHelperContent Content { get; }
         public int Order { get; }
         public Dictionary<string, object> Attributes { get; }
     }

--- a/ScriptCaptureTagHelper/Types/ScriptCapture.cs
+++ b/ScriptCaptureTagHelper/Types/ScriptCapture.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace ScriptCaptureTagHelper.Types
 {
@@ -6,7 +7,7 @@ namespace ScriptCaptureTagHelper.Types
     {
         private readonly List<ScriptBlock> _scriptBlocks = new List<ScriptBlock>();
 
-        public void Add(string content, Dictionary<string, object> attributes, int order)
+        public void Add(TagHelperContent content, Dictionary<string, object> attributes, int order)
         {
             var block = new ScriptBlock(content, attributes, order);
             lock (_scriptBlocks)


### PR DESCRIPTION
- Reduce allocations by storing content as `TagHelperContent` on `ScriptBlock` rather than `string` and using methods accepting `IHtmlContent`
- Add benchmarks and unit tests
- Add sample project
- Fix instructions on how to add library

#### Results of benchmark that compares `Process` method execution on `ScriptRenderTagHelper`
``` ini

BenchmarkDotNet=v0.10.13, OS=ubuntu 17.04
Intel Core i7-7700 CPU 3.60GHz (Kaby Lake), 1 CPU, 8 logical cores and 4 physical cores
.NET Core SDK=2.1.300-preview1-008174
  [Host]     : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.1.0-preview1-26216-03 (CoreCLR 4.6.26216.04, CoreFX 4.6.26216.02), 64bit RyuJIT


```
|     Method | StringLength |      Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|----------- |------------- |----------:|----------:|----------:|---------:|---------:|---------:|----------:|
|    **Process** |         **1000** |  **1.860 us** | **0.0348 us** | **0.0291 us** |   **2.6913** |        **-** |        **-** |  **11.03 KB** |
| NewProcess |         1000 |  1.186 us | 0.0385 us | 0.1059 us |   1.6327 |        - |        - |    6.7 KB |
|    **Process** |        **10000** |  **8.066 us** | **0.1608 us** | **0.3427 us** |  **23.1476** |        **-** |        **-** |     **95 KB** |
| NewProcess |        10000 |  4.646 us | 0.0926 us | 0.1670 us |  13.5117 |   1.9302 |        - |  55.52 KB |
|    **Process** |       **100000** | **98.133 us** | **1.8977 us** | **2.5976 us** | **249.8779** | **249.8779** | **249.8779** | **798.13 KB** |
| NewProcess |       100000 | 52.534 us | 1.0452 us | 1.2036 us | 124.9390 | 124.9390 | 124.9390 | 407.09 KB |