### PR TITLE
Fix for Duplicate Bug

### DIFF
--- a/src/CaptureRenderTagHelper/RenderTagHelper.cs
+++ b/src/CaptureRenderTagHelper/RenderTagHelper.cs
@@ -72,7 +72,7 @@ namespace CaptureRenderTagHelper
             if (NoDuplicates)
             {
                 blocks = blocks
-                    .GroupBy(b => b.Attributes.ContainsKey(NoDuplicateSource) ? b.Attributes[NoDuplicateSource] : Guid.NewGuid())
+                    .GroupBy(b => b.Attributes.ContainsKey(NoDuplicateSource) ? b.Attributes[NoDuplicateSource].ToString() : Guid.NewGuid().ToString())
                     .Select(b => b.First());
             }
 


### PR DESCRIPTION
no-duplicates does not work for me in a .Net Core 7 ASP.ENT app. The reason is that the GroupBy clause which removes the duplicates works on the attribute value, which is . This will give a seperate group for each attribute, even if the string value of the attribute value is the same.

Casting the attribute values to string inside of the group clauses fixes the problem. See pull request.

Note: The tests contained in the original solution all pass, but in my ASP.NET Core 7 app, the problem shows up.